### PR TITLE
fix(treeview): Fix scrolling behavoir and add proper MouseMove handling

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -916,7 +916,7 @@ func (t *TreeView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 			t.lastMouseY = y
 			consumed = true
 		case MouseMove:
-			if t.lastMouseY != -1 {
+			if event.Buttons()&tcell.Button1 != 0 && t.lastMouseY != -1 {
 				t.movement = treeScroll
 				t.step = t.lastMouseY - y
 				t.lastMouseY = y


### PR DESCRIPTION
Old behavior was bugged and incorrect, a MouseLeftClick would not account for scrolling. Example: (Discordo selected the incorrect channel because it was using the old (non-scrolled) `y` coords)
![old](https://github.com/user-attachments/assets/f2ec1dcd-aa15-488e-af26-2718cce320ee)

New behavior fixes that and allows touch-like scrolling (holding down left click and moving the mouse up and down actual scrolls). Example:
![new](https://github.com/user-attachments/assets/d19e5dd2-9220-4dfc-a5d4-80e91e52a7a3)

This PR won't effect any user of Tview. This is purely internal.

If you see coloring artifacts in the GIFs, it's because these GIFs are 1600x866 in pixels, there's no artifacts in the actual recording.